### PR TITLE
✨ refactor BusStops to optimize stop_times loading and filtering

### DIFF
--- a/src/components/BusStops.tsx
+++ b/src/components/BusStops.tsx
@@ -1,5 +1,5 @@
 import { CircleMarker, Popup } from "react-leaflet";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { parseStopTimes } from "@/lib/routeUtil";
 import { useVehicleStore } from "@/store/vehicleStore";
 
@@ -22,50 +22,13 @@ export default function BusStops({ selectedRoute, stopsData }: BusStopsProps) {
     new Set()
   );
   const vehicles = useVehicleStore((state) => state.vehicles);
+  // Fix type definition to match what parseStopTimes actually returns
+  const [tripToStopsMap, setTripToStopsMap] = useState<
+    Map<string, Array<{ stopId: string; sequence: number }>>
+  >(new Map());
+  const [isStopTimesLoaded, setIsStopTimesLoaded] = useState(false);
 
-  // Fetch stop_times.txt data
-  useEffect(() => {
-    if (selectedRoute === "all") return;
-
-    fetch("/api/stop_times")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error ${response.status}`);
-        }
-        return response.text();
-      })
-      .then((data) => {
-        console.log(`Received stop_times data: ${data.length} bytes`);
-
-        // Parse the stop times data directly without storing in state
-        const parsedTripToStops = parseStopTimes(data);
-
-        // Find relevant trip IDs for this route
-        const routeVehicles = vehicles.filter(
-          (v) => v.routeId === selectedRoute
-        );
-        if (routeVehicles.length > 0) {
-          // Get all stop IDs for these trip IDs
-          const stopIdsForRoute = new Set<string>();
-          for (const vehicle of routeVehicles) {
-            const tripId = vehicle.tripId;
-            if (parsedTripToStops.has(tripId)) {
-              const stopSequences = parsedTripToStops.get(tripId)!;
-              stopSequences.forEach((item) => stopIdsForRoute.add(item.stopId));
-            }
-          }
-          console.log(
-            `Found ${stopIdsForRoute.size} stops for route ${selectedRoute}`
-          );
-          setRelevantStopIds(stopIdsForRoute);
-        }
-      })
-      .catch((error) => {
-        console.error("Error loading stop_times data:", error);
-      });
-  }, [selectedRoute]);
-
-  // Parse stops.txt data
+  // Parse stops.txt data - do this first and only once when stopsData changes
   useEffect(() => {
     if (!stopsData) return;
 
@@ -89,15 +52,76 @@ export default function BusStops({ selectedRoute, stopsData }: BusStopsProps) {
     setStops(parsedStops);
   }, [stopsData]);
 
-  // Filter stops by route if a specific route is selected
-  const stopsToShow =
-    selectedRoute === "all"
-      ? stops
-      : stops.filter((stop) => relevantStopIds.has(stop.stop_id));
+  // Fetch stop_times.txt data only once
+  useEffect(() => {
+    // If we've already loaded the data, don't do it again
+    if (isStopTimesLoaded) return;
+
+    fetch("/api/stop_times")
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((data) => {
+        console.log(`Received stop_times data: ${data.length} bytes`);
+        // Parse the stop times data and store the mapping for reuse
+        const parsedData = parseStopTimes(data);
+        setTripToStopsMap(parsedData);
+        setIsStopTimesLoaded(true);
+      })
+      .catch((error) => {
+        console.error("Error loading stop_times data:", error);
+      });
+  }, [isStopTimesLoaded]);
+
+  // Find relevant stops based on selected route - do this when route or trip data changes
+  useEffect(() => {
+    if (selectedRoute === "all" || !isStopTimesLoaded) return;
+
+    // Find relevant trip IDs for this route
+    const routeVehicles = vehicles.filter((v) => v.routeId === selectedRoute);
+
+    if (routeVehicles.length > 0) {
+      // Get all stop IDs for these trip IDs - make this more efficient
+      const stopIdsForRoute = new Set<string>();
+
+      for (const vehicle of routeVehicles) {
+        const tripId = vehicle.tripId;
+        if (tripToStopsMap.has(tripId)) {
+          const stopSequences = tripToStopsMap.get(tripId)!;
+          for (const item of stopSequences) {
+            // Using 'sequence' property instead of 'stopSequence'
+            stopIdsForRoute.add(item.stopId);
+          }
+        }
+      }
+
+      console.log(
+        `Found ${stopIdsForRoute.size} stops for route ${selectedRoute}`
+      );
+      setRelevantStopIds(stopIdsForRoute);
+    }
+  }, [selectedRoute, tripToStopsMap, vehicles, isStopTimesLoaded]);
+
+  // Memoize the filtered stops to avoid recalculating on every render
+  const stopsToShow = useMemo(() => {
+    if (selectedRoute === "all") return stops;
+    return stops.filter((stop) => relevantStopIds.has(stop.stop_id));
+  }, [stops, selectedRoute, relevantStopIds]);
+
+  // Limit the number of stops rendered at once for better performance
+  const maxStopsToRender = 200; // Adjust this number based on performance testing
+  const limitedStops = useMemo(() => {
+    if (stopsToShow.length <= maxStopsToRender) return stopsToShow;
+    // If we have too many stops, prioritize showing the relevant ones
+    return stopsToShow.slice(0, maxStopsToRender);
+  }, [stopsToShow]);
 
   return (
     <>
-      {stopsToShow.map((stop) => (
+      {limitedStops.map((stop) => (
         <CircleMarker
           key={stop.stop_id}
           center={[stop.stop_lat, stop.stop_lon]}


### PR DESCRIPTION
Fix type definitions for tripToStopsMap to match parseStopTimes output.
Load stop_times data only once and store parsed results in state for reuse.
Separate concerns by fetching stopsData and stop_times independently.
Improve filtering logic to efficiently find relevant stops per selected route.
Memoize filtered stops and limit rendered stops to enhance performance.