### PR TITLE
✨ feat: add theme support with dark/light toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "leaflet": "^1.9.4",
         "lucide-react": "^0.485.0",
         "next": "15.2.4",
+        "next-themes": "^0.4.6",
         "node-fetch": "^3.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6325,6 +6326,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.485.0",
     "next": "15.2.4",
+    "next-themes": "^0.4.6",
     "node-fetch": "^3.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import ClientLayout from "./ClientLayout";
 import "./globals.css";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { GtfsDataLoader } from "./GtfsDataLoader";
+import { ThemeProvider } from "@/components/theme-provider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -18,8 +19,18 @@ export default async function RootLayout({
   await GtfsDataLoader();
 
   return (
-    <html lang="en">
-      <ClientLayout>{children}</ClientLayout>
+    <html lang="en" suppressHydrationWarning>
+      <head />
+      <ClientLayout>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+        </ThemeProvider>
+      </ClientLayout>
       <SpeedInsights />
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import MapWrapper from "@/components/MapWrapper";
 import TrackButton from "@/components/TrackButton";
 import GtfsUpdateButton from "@/components/GtfsUpdateButton";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 export default function Home() {
   return (
@@ -8,6 +9,7 @@ export default function Home() {
       <main className="flex min-h-screen flex-col items-center justify-between p-24">
         <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
           <h1 className="text-2xl font-bold">Bus Tracker</h1>
+          <ThemeToggle />
         </div>
 
         <div className="w-full max-w-5xl flex flex-col items-start gap-4">

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { setTheme, theme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+    >
+      <Sun className="h-[1.5rem] w-[1.3rem] dark:hidden" />
+      <Moon className="hidden h-5 w-5 dark:block" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
Introduce next-themes for theme management and wrap the app with
a ThemeProvider to enable system and manual theme switching. Add a
ThemeToggle button to the homepage for users to switch between light
and dark modes. This improves user experience by supporting preferred
color schemes and accessibility.